### PR TITLE
Feature/auto spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,11 @@ c.JupyterHub.load_roles = [
 # jupyterhub_config.py
 from e2x_course_hub.kubespawner_hooks import (
     get_profile_list_hook,
-    get_pre_spawn_hook
+    get_pre_spawn_hook,
+    configure_autospawn
 )
+
+from e2x_course_hub.course_service._data import KUBESPAWNER_TEMPLATE_PATH, JUPYTERHUB_TEMPLATE_PATH
 
 # Configure KubeSpawner
 c.JupyterHub.spawner_class = 'kubespawner.KubeSpawner'
@@ -266,7 +269,31 @@ c.KubeSpawner.profile_list = get_profile_list_hook(
 c.KubeSpawner.pre_spawn_hook = get_pre_spawn_hook(
     server_config_file='/etc/jupyterhub/config.yml'
 )
+
+# Configure JupyterHub and the KubeSpawner to use the templates from e2x_course_hub
+c.KubeSpawner.additional_profile_form_template_paths = [KUBESPAWNER_TEMPLATE_PATH]
+
+c.JupyterHub.template_paths = [JUPYTERHUB_TEMPLATE_PATH]
+
+# Optional: Configure autospawn behavior
+# Automatically spawns the server if only one course/profile is available
+configure_autospawn(
+    c,
+    auto_spawn_single_course=True,  # Enable auto-spawn for single course
+    auto_spawn_countdown=5           # Countdown in seconds before spawning
+)
 ```
+
+#### Autospawn Configuration
+
+The `configure_autospawn` function adds template variables to control automatic server spawning behavior:
+
+- **`auto_spawn_single_course`** (bool): When `True`, automatically spawns the server if the user has access to only one course/profile. Default: `False`
+- **`auto_spawn_countdown`** (int): Number of seconds to show a countdown before auto-spawning. Gives users time to cancel if needed. Default: `5`
+
+This function safely merges with any existing `template_vars` in your configuration, preserving other template variables you may have set.
+
+**Note**: For autospawn to work, you need custom JupyterHub templates that implement the autospawn logic using these template variables.
 
 ### Standalone Course Service
 

--- a/e2x_course_hub/kubespawner_hooks.py
+++ b/e2x_course_hub/kubespawner_hooks.py
@@ -1,6 +1,8 @@
 import re
 from typing import Callable, Dict, List, Optional
 
+from traitlets.config import Config
+
 from .api.profile_api import ProfileAPI
 from .schema.profile import ResolvedProfile
 from .schema.server import Server
@@ -201,3 +203,26 @@ def get_pre_spawn_hook(server_config_file: str) -> Callable:
         # spawner.volume_mounts = []
 
     return hook
+
+
+def configure_autospawn(
+    config: Config, auto_spawn_single_course: bool = True, auto_spawn_countdown: int = 5
+):
+    """
+    Configures the autospawn hooks in the given JupyterHub config.
+
+    Args:
+        config (Config): The JupyterHub configuration object to modify.
+        auto_spawn_single_course (bool): Whether to auto-spawn a single course if only
+            one profile is available.
+        auto_spawn_countdown (int): The countdown time in seconds before auto-spawning.
+    """
+    if config.JupyterHub.template_vars is None:
+        config.JupyterHub.template_vars = {}
+
+    config.JupyterHub.template_vars.update(
+        {
+            "auto_spawn_single_course": auto_spawn_single_course,
+            "auto_spawn_countdown": auto_spawn_countdown,
+        }
+    )

--- a/e2x_course_hub/kubespawner_hooks.py
+++ b/e2x_course_hub/kubespawner_hooks.py
@@ -206,7 +206,7 @@ def get_pre_spawn_hook(server_config_file: str) -> Callable:
 
 
 def configure_autospawn(
-    config: Config, auto_spawn_single_course: bool = True, auto_spawn_countdown: int = 5
+    config: Config, auto_spawn_single_course: bool = False, auto_spawn_countdown: int = 5
 ):
     """
     Configures the autospawn hooks in the given JupyterHub config.

--- a/share/e2x_course_hub/templates/jupyterhub/spawn.html
+++ b/share/e2x_course_hub/templates/jupyterhub/spawn.html
@@ -25,5 +25,7 @@
   {{ super() }}
   <script>
       window.url = "{{ url }}";
+      window.autoSpawnSingleCourse = {{ auto_spawn_single_course | default(false) | tojson }};
+      window.autoSpawnCountdown = {{ auto_spawn_countdown | default(5) | tojson }};
   </script>
 {% endblock script %}

--- a/share/e2x_course_hub/templates/kubespawner/form.html
+++ b/share/e2x_course_hub/templates/kubespawner/form.html
@@ -407,6 +407,61 @@ Create a card for a profile, complete with launch buttons and overrides
           urlInputs.forEach(input => input.value = window.url);
       });
 
+      // Only auto-spawn if enabled and there is exactly one profile with one role option
+      if (window.autoSpawnSingleCourse) {
+          const launchButtons = document.querySelectorAll(".js-launch-role");
+          if (launchButtons.length === 1) {
+              const singleForm = launchButtons[0].closest("form") || launchButtons[0].closest(".spawner-form");
+              if (singleForm) {
+                  const countdown = window.autoSpawnCountdown ?? 5;
+                  const courseName = document.querySelector(".course-card h5")?.textContent?.trim() || "your course";
+
+                  if (countdown <= 0) {
+                      singleForm.submit();
+                      return;
+                  }
+
+                  document.querySelector(".view-toggle-container").style.display = "none";
+                  document.getElementById("semesterAccordion").style.display = "none";
+
+                  const overlay = document.createElement("div");
+                  overlay.innerHTML = `
+                      <div style="text-align:center; padding:3rem 1rem; color:#333;">
+                          <i class="fa fa-rocket" style="font-size:3rem; color:#079dde; margin-bottom:1rem; display:block;"></i>
+                          <h4 style="margin-bottom:0.5rem;">Launching <strong>${courseName}</strong></h4>
+                          <p style="font-size:1.1rem;">Automatically spawning in <strong id="countdown-seconds">${countdown}</strong> seconds&hellip;</p>
+                          <button id="cancel-autolaunch" class="btn btn-outline-secondary btn-sm" style="margin-top:1rem;">
+                              <i class="fa fa-times"></i> Cancel
+                          </button>
+                      </div>
+                  `;
+                  document.getElementById("semesterAccordion").parentNode.insertBefore(
+                      overlay, document.getElementById("semesterAccordion")
+                  );
+
+                  let remaining = countdown;
+                  const countdownEl = document.getElementById("countdown-seconds");
+                  const timer = setInterval(() => {
+                      remaining--;
+                      countdownEl.textContent = remaining;
+                      if (remaining <= 0) {
+                          clearInterval(timer);
+                          singleForm.submit();
+                      }
+                  }, 1000);
+
+                  document.getElementById("cancel-autolaunch").addEventListener("click", () => {
+                      clearInterval(timer);
+                      overlay.remove();
+                      document.querySelector(".view-toggle-container").style.display = "";
+                      document.getElementById("semesterAccordion").style.display = "";
+                  });
+
+                  return; // Skip rest of UI setup while countdown is active
+              }
+          }
+      }
+
       // View toggle functionality
       const detailedViewBtn = document.getElementById("detailedViewBtn");
       const compactViewBtn = document.getElementById("compactViewBtn");


### PR DESCRIPTION
This implements #2 

This pull request introduces an autospawn feature for JupyterHub, allowing automatic server spawning when a user has access to only one course or profile. The implementation includes backend configuration hooks, template variable propagation, and frontend UI logic for countdown and cancellation. The changes are grouped below by backend configuration, template updates, and frontend behavior.

**Backend configuration and hooks:**

* Added the `configure_autospawn` function in `e2x_course_hub/kubespawner_hooks.py` to set `auto_spawn_single_course` and `auto_spawn_countdown` template variables in the JupyterHub config, enabling autospawn behavior.
* Updated the example in `README.md` to show how to use `configure_autospawn` and set template paths for JupyterHub and KubeSpawner. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L256-R261) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R272-R297)

**Template and variable propagation:**

* Injected `auto_spawn_single_course` and `auto_spawn_countdown` variables into the JavaScript context in `share/e2x_course_hub/templates/jupyterhub/spawn.html` for use in frontend logic.

**Frontend autospawn logic and UI:**

* Implemented autospawn countdown and cancellation UI in `share/e2x_course_hub/templates/kubespawner/form.html`, automatically submitting the form if only one course/profile is available and autospawn is enabled.